### PR TITLE
Improvement

### DIFF
--- a/smartcontract/assembly/index.ts
+++ b/smartcontract/assembly/index.ts
@@ -1,123 +1,160 @@
-import { Item, itemsStorage, ownersStorage} from './model';
+import { Item, itemsStorage, ownersStorage } from "./model";
 import { context, ContractPromiseBatch, u128 } from "near-sdk-as";
 
-
- // buying a game item from the marketplace
+// buying a game item from the marketplace
 export function buyGameItem(itemId: string): void {
-    const item = getItem(itemId);
-    if (item == null) {
-        throw new Error("game item not found");
-    }
-    if (item.price.toString() != context.attachedDeposit.toString()) {
-        throw new Error("attached deposit should be greater than the item price");
-    }
-    if (item.forSale !== true){
-        throw new Error("item is not for sale")
-    }
+	const item = getItem(itemId);
+	if (item == null) {
+		throw new Error("game item not found");
+	}
+	assert(
+		item.price.toString() == context.attachedDeposit.toString(),
+		"attached deposit should be greater than the item price"
+	);
+	assert(item.forSale == true, "Item is not for sale");
+	assert(
+		item.owner.toString() != context.sender.toString(),
+		"You can't buy your own item"
+	);
+	ContractPromiseBatch.create(item.owner).transfer(context.attachedDeposit);
+	item.buyItem();
+	itemsStorage.set(item.id, item);
+}
 
-    ContractPromiseBatch.create(item.owner).transfer(context.attachedDeposit);
-    item.forSale = false;
-    itemsStorage.set(item.id, item);
+/**
+ * @dev request a game item exchange
+ * @param requestItemId id of the item caller wishes to trade his item with
+ * @param forItemId id of the item set for exchange by caller
+ */
+export function requestExchange(
+	requestItemId: string,
+	forItemId: string
+): void {
+
+	const forItem = getItem(forItemId);
+	const requestItem = getItem(requestItemId);
+	
+  if (forItem == null || requestItem == null) {
+		throw new Error("one of the game items not found");
+	}
+  assert(forItem.owner.toString() == context.sender.toString(),"You don't have permission to exchange this item");
+  assert(requestItem.forExchange == true && forItem.forExchange == true,"one of the items is not available for exchange");
+  assert(requestItem.canBeExchanged() == true, "Requested item already has a request for trade");
+  assert(forItem.canBeExchanged() == true, "For item already has a request for trade");
   
+  forItem.lockForExchange(requestItem.id);
+  requestItem.requestExchange(forItem.id);
+	itemsStorage.set(requestItem.id, requestItem);
+	itemsStorage.set(forItem.id, forItem);
 }
-
-// exchanging a game item by passing in your own item id to be traded
-export function exchangeGameItem(owneritemId: string, calleritemId: string): void {
-  const owneritem = getItem(owneritemId);
-  const calleritem = getItem(calleritemId);
-  const caller = getOwnerExist(context.sender)
-  if (owneritem == null) {
-      throw new Error("game item not found");
-  }
-
-  if ( caller != true) {
-    throw new Error("you don't have an item to exchange");
-}
-
-  if (calleritem == null) {
-    throw new Error("game item not found");
-}
-
-if (calleritem.owner != context.sender.toString()) {
-  throw new Error("You don't have permission to exchange this item");
-}
-
-  if (owneritem.forExchange != true){
-    throw new Error("this item is not available for exchange");
-}
-if (calleritem.forExchange != true){
-  throw new Error("this item is not available for exchange");
-}
- 
- 
-  owneritem.owner = calleritem.owner;
-  calleritem.owner = owneritem.owner;
-
-  itemsStorage.set(owneritem.id, owneritem);
-  itemsStorage.set(calleritem.id, calleritem);
-}
-
-
-
-// changing the forsale property of a gaming item
-  export function toggleForsale(itemId: string): void {
-    const item = getItem(itemId);
-    if (item == null) {
-      throw new Error("item not found");
-    }
-    if (item.owner != context.sender.toString()) {
-        throw new Error("You don't have permission");
-    }
-    item.forSale = !item.forSale; 
-    itemsStorage.set(item.id, item); 
-  }
-
-
-// changing the forexchange property of the game item
-  export function toggleForexchange(itemId: string): void {
-    const item = getItem(itemId);
-    if (item == null) {
-      throw new Error("item not found");
-    }
-    if (item.owner != context.sender.toString()) {
-        throw new Error("You don't have permission");
-    }
-    item.forExchange = !item.forExchange; 
-    itemsStorage.set(item.id, item); 
-  }
-
-
-
 
 
 /**
- * 
+ * @dev reject a request for exchange
+ * @param requestItemId id of the item caller wishes to trade his item with
+ * @param forItemId id of the item set for exchange by caller
+ */
+ export function rejectExchange(
+	itemId: string
+): void {
+
+	const item= getItem(itemId);
+	
+  if (item == null) {
+		throw new Error("game item not found");
+	}
+  assert(item.owner.toString() == context.sender.toString(),"You don't have permission to exchange this item");
+  assert(item.canBeExchanged() == false, "Requested item doesn't have a request for trade");
+
+  const forItem = getItem(item.requestExchangeId);
+  if(forItem == null){
+    throw new Error("game item not found");
+  }
+  item.rejectExchange();
+  forItem.rejectExchange();
+	itemsStorage.set(item.id, item);
+	itemsStorage.set(forItem.id, forItem);
+}
+
+/**
+ * @dev allow items' owners to accept a trading offer and initiate the trade
+ * @param itemId of item to initiate exchange offer
+ */
+export function exchangeGameItem(
+	itemId: string
+): void {
+
+	const item= getItem(itemId);
+	
+  if (item == null) {
+		throw new Error("game item not found");
+	}
+  assert(item.owner.toString() == context.sender.toString(),"You don't have permission to exchange this item");
+  assert(item.canBeExchanged() == false, "Requested item doesn't have a request for trade");
+  
+  const forItem = getItem(item.requestExchangeId);
+  if(forItem == null){
+    throw new Error("game item not found");
+  }
+  item.exchange(forItem.owner);
+  forItem.exchange(context.predecessor);
+	itemsStorage.set(item.id, item);
+	itemsStorage.set(forItem.id, forItem);
+}
+
+// changing the forsale property of a gaming item
+export function toggleForsale(itemId: string): void {
+	const item = getItem(itemId);
+	if (item == null) {
+		throw new Error("item not found");
+	}
+	if (item.owner != context.sender.toString()) {
+		throw new Error("You don't have permission");
+	}
+  assert(item.canBeExchanged() == true, "You have to reject the current trading offer first");
+	item.toggleForSale();
+	itemsStorage.set(item.id, item);
+}
+
+// changing the forexchange property of the game item
+export function toggleForexchange(itemId: string): void {
+	const item = getItem(itemId);
+	if (item == null) {
+		throw new Error("item not found");
+	}
+	if (item.owner != context.sender.toString()) {
+		throw new Error("You don't have permission");
+	}
+  assert(item.forSale == false, "Item needs to not be on sale");
+  assert(item.canBeExchanged() == true, "You have to reject the current trading offer first");
+	item.toggleForExchange();
+	itemsStorage.set(item.id, item);
+}
+
+/**
+ *
  * adding an item to the marketplace
  */
 export function setItem(item: Item): void {
-    let storedItem = itemsStorage.get(item.id);
-    if (storedItem !== null) {
-        throw new Error(`an item with id=${item.id} already exists`);
-    }
-    itemsStorage.set(item.id, Item.fromPayload(item));
-    ownersStorage.set(context.sender, true);
+	let storedItem = itemsStorage.get(item.id);
+	if (storedItem !== null) {
+		throw new Error(`an item with id=${item.id} already exists`);
+	}
+	itemsStorage.set(item.id, Item.fromPayload(item));
+	ownersStorage.set(context.sender, true);
+}
+
+export function getItem(id: string): Item | null {
+	return itemsStorage.get(id);
 }
 
 
-export function getItem(id: string): Item| null {
-    return itemsStorage.get(id);
-}
-
-
-export function getOwnerExist(address: string): bool| null {
-  return ownersStorage.get(address);
-}
 
 /**
- * 
+ *
  * A function that returns an array of itemsfor all accounts
- * 
+ *
  */
 export function getItems(): Array<Item> {
-    return itemsStorage.values();
+	return itemsStorage.values();
 }

--- a/smartcontract/assembly/index.ts
+++ b/smartcontract/assembly/index.ts
@@ -1,4 +1,4 @@
-import { Item, itemsStorage, ownersStorage } from "./model";
+import { Item, itemsStorage} from "./model";
 import { context, ContractPromiseBatch, u128 } from "near-sdk-as";
 
 // buying a game item from the marketplace

--- a/smartcontract/assembly/model.ts
+++ b/smartcontract/assembly/model.ts
@@ -12,7 +12,9 @@ export class Item {
     owner: string;
     forSale: bool;
     forExchange: bool;
-
+    requestExchangeId: string; // id of the item a user wants to trade the current item with
+    approvedExchange: bool; // boolean to keep track of whether requestExchangeId has been accepted by the item owner
+    approvedId: string; // agreed item's id to exchange with
     public static fromPayload(payload: Item): Item {
         const item = new Item();
         item.id = payload.id;
@@ -27,10 +29,59 @@ export class Item {
         return item;
     }
     
+    public buyItem(): void {
+        this.forSale = false;
+        this.forExchange = false;
+        this.owner = context.sender;
+    }
+
+    public rejectExchange(): void {
+        this.requestExchangeId = "";
+        this.approvedExchange = false;
+        this.approvedId = "";
+    }
+    
+    public requestExchange(itemId: string): void {
+        this.requestExchangeId = itemId;
+        this.forExchange = false; // to prevent override of the first request for exchange
+    }
+    // locks an item for an exchange after request an exchanging offer
+    public lockForExchange(itemId: string): void {
+        this.forExchange = false;
+        this.requestExchangeId = "";
+        this.approvedExchange = true;
+        this.approvedId = itemId;
+    }
+    
+    /**
+     * 
+     * @returns bool whether item can have request for trades/toggle exchange status/ toggle sale status
+     */
+    public canBeExchanged(): bool {
+        if(this.requestExchangeId != "" || this.approvedId != ""){
+            return false;
+        }else {
+            return true;
+        }
+    }
+
+    public exchange(owner: string): void {
+        this.approvedExchange = false;
+        this.approvedId = "";
+        this.forSale = false;
+        this.owner = owner;
+    }
+
+    public toggleForSale(): void {
+        this.forSale = !this.forSale;
+    }
+
+    public toggleForExchange(): void {
+        this.forExchange = !this.forExchange;
+    }
 
 }
 
 
 
 export const itemsStorage = new PersistentUnorderedMap<string, Item>("LISTED_ITEMS");
-export const ownersStorage = new PersistentUnorderedMap<string, bool>("LISTED_OWNERS");


### PR DESCRIPTION
## Fixes and Improvements

1. Items' owners could buy their own items
2. Items allowed for trade could be exchanged with any other item (which could cause issues if one of the traded items' owners did not want to trade with that item), so I've went ahead and added a few new variables in the model Item to be able to implement the functions: requestExchange and rejectExchange while also modifying the exchangeGameItem function.
3.  Moved any logic/code making changes to an item into the model Item as inherited methods for best practices
4. When buying an item, the owner was never switched. Furthermore, items could be both for exchange and on sale which could cause logistic issues as bought items could still be traded after being bought (unless the new owner toggles the exchange status). 
5.  When items were exchanged, the exchange status wasn't updated.
6. Added checks to prevent items on trade to be exchanged or items available to be exchanged to be on sale